### PR TITLE
Add docs for column count tag

### DIFF
--- a/_glossary/side-columns/column-count.md
+++ b/_glossary/side-columns/column-count.md
@@ -1,0 +1,33 @@
+---
+layout: side-nav
+title: Side Column Count
+last-updated: 30-03-2015
+nav-position: 1
+parent: side-columns
+tag: <!--WDK:column:count-->
+---
+
+This tag returns the amount of side columns the user has enabled. Either 0, 1 or 2.
+
+
+## Example
+
+In the following example we are outputting the count on the body as a class. The Create templates use this method for styling the page content based on how many side columns are in use.
+
+~~~
+<body class="wdk_columnCount_<!--WDK:column:count-->">
+	...
+</body>
+~~~
+
+~~~
+.wdk_columnCount_0 .page-wrapper {
+	width: 100%
+}
+.wdk_columnCount_1 .page-wrapper {
+	width: 80%
+}
+.wdk_columnCount_2 .page-wrapper {
+	width: 60%
+}
+~~~

--- a/_glossary/side-columns/index.md
+++ b/_glossary/side-columns/index.md
@@ -7,6 +7,7 @@ sub-pages:
   - content
   - end
   - id
+  - column-count
   - item-start
   - nth-item
   - start

--- a/_tutorials/converting-to-wdk.md
+++ b/_tutorials/converting-to-wdk.md
@@ -821,7 +821,7 @@ We now have our existing webpage compatible with Create's WDK. Heres a final ove
     </style>
 </head>
 
-<body id="top">
+<body id="top" class="wdk_columnCount_<!--WDK:column:count-->">
     <div id="wrapper">
     
         <header>

--- a/_tutorials/the-header.md
+++ b/_tutorials/the-header.md
@@ -34,7 +34,7 @@ Below is a simplified version of a header.
     <style type="text/css" media="screen"> </style>
   </head>
 
-  <body>
+  <body class="wdk_columnCount_<!--WDK:column:count-->">
     <div id="site">
 
       <header>

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,9 @@ layout: index
 title: Change Log
 ---
 
+## 30th March 2015 - Column Count Tag
+Add documentation for `<!--WDK:column:count-->`, required for the default styling of the new re-sizeable category layout.
+
 ## 4th March 2015 - Colours
 Updates to how colour tags are used as the Design Studio handles these slightly differently to before.
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@ title: Change Log
 ---
 
 ## 30th March 2015 - Column Count Tag
-Add documentation for `<!--WDK:column:count-->`, required for the default styling of the new re-sizeable category layout.
+Add documentation for `<!--WDK:column:count-->`, required for the default styling of the new re-sizeable category grid layout.
 
 ## 4th March 2015 - Colours
 Updates to how colour tags are used as the Design Studio handles these slightly differently to before.


### PR DESCRIPTION
Pretty self explanatory really.

Maybe this is too much for a glossary page? It will be much nicer in the side by side docs thing rather than a tutorial I think. Leaving it here for reference? Deleting it all together? I'm impartial...

@AidanThreadgold 

P.S I haven't tested this with `jekyll serve` because its broken on my computer....
