### PR TITLE
Update the base-shop tag description.

### DIFF
--- a/_tutorials/requirements-restrictions.md
+++ b/_tutorials/requirements-restrictions.md
@@ -82,13 +82,16 @@ Modernizr is a feature detection javascript library that enables you to provide 
 
 This script is the defacto way to enable use of HTML5 sectioning elements in legacy Internet Explorer. For more info [view the forked repository on GitHub](https://github.com/createdotnet/html5shiv).
 
-#### Shop
+#### Shop Styling
 
-We are providing a selection of base styles for the shop in the `<!--WDK:base:css:shop-->` tag. Although it is not essential that you include these base styles, they are every minimal and are required for some of the shop functionality. It is recommended that you add your own shop CSS to compliment these styles.
+If your template is to be used with a shop, you will find it useful to include the `<!--WDK:base:css:shop-->` tag.
 
-**Included Styles**
-* Tiled Category Layout widths (non-responsive)
+This tag provides the following selection of base shop styles;
+- Category Layout (The included grid widths are not currently responsive)
+- Product Page Layout
+- Product Summary Object (The indivdual product 'cards' that include an image, price and product title).
 
+You may wish to add your own shop CSS to compliment these styles.
 
 #### Grid
 

--- a/changelog/index.md
+++ b/changelog/index.md
@@ -3,9 +3,14 @@ layout: index
 title: Change Log
 ---
 
+## 1 October 2015 - Version 1.2
+
+- For users on version 1.2 and higher many of the shop styles will have been removed. You will need to style these in your CSS file or include the `<!--WDK:base:css:shop-->` tag in the `<head>` of your WDK template. This will allow for greater flexibility in the shop styling.
+
+
 ## 22 June 2015 - Improve file path documentation.
 
-* Reworded existing file path documentation and added further explanation as to where files are uploaded to and under which context.
+- Reworded existing file path documentation and added further explanation as to where files are uploaded to and under which context.
 
 ## 11 May 2015 - Template thumbnails
 Fixed bug where template thumbnails weren't shown in the Design Studio. 


### PR DESCRIPTION
We're updating what the base:css:shop tag includes so this reflects that change in the requirements and restrictions tutorial.

Also adds a version 1.2 to the change log.

See - https://github.com/createdotnet/dyos_html/pull/1048
@benjaminparry 
